### PR TITLE
qcom: Remove QCOM_DIRECTTRACK

### DIFF
--- a/core/qcom_target.mk
+++ b/core/qcom_target.mk
@@ -26,11 +26,7 @@ ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
     # Tell HALs that we're compiling an AOSP build with an in-line kernel
     TARGET_COMPILE_WITH_MSM_KERNEL := true
 
-    # Enable DirectTrack for legacy targets
     ifneq ($(filter msm7x30 msm8660 msm8960,$(TARGET_BOARD_PLATFORM)),)
-        ifeq ($(BOARD_USES_LEGACY_ALSA_AUDIO),true)
-            qcom_flags += -DQCOM_DIRECTTRACK
-        endif
         # Enable legacy graphics functions
         qcom_flags += -DQCOM_BSP_LEGACY
     endif


### PR DESCRIPTION
* DirectTrack/LPA/tunnel for 8960 only works with AwesomePlayer, which
  has been deprecated. Don't bother allowing this to compile.

Change-Id: I4d3e6dd9f1e3047a379fd76af4f6b45d791210de